### PR TITLE
No longer replacing uri in page

### DIFF
--- a/twdocs.module
+++ b/twdocs.module
@@ -346,7 +346,7 @@ function twdocs_submit_revision(&$node) {
   }
   $node2 = node_load($node->nid);
   $str = $node2->body;
-  $str = preg_replace("|".$_POST["url"]."|",$result->persist,$str);
+  //$str = preg_replace("|".$_POST["url"]."|",$result->persist,$str);
   $node2->body = $str;
   $node2->uid = $user->uid;
   $node2->name = $user->name;
@@ -458,6 +458,9 @@ function twdocs_parse_params($matches) {
     $count = preg_match_all("/([[:alpha:]]*)=\"([^\"]*)\"/",$paramText[$i][0],$pairs);
     for($j=0;$j<$count;$j++) {
       switch($pairs[1][$j]) {
+      case "usemap":
+	$desc["usemap"] = $pairs[2][$j];
+	break;
       case "style":
 	$desc["style"] = $pairs[2][$j];
 	break;
@@ -584,6 +587,9 @@ function twdocs_place_reference($params, &$node) {
     if(isset($params["style"])) {
       $value .= ' style="'.$params["style"].'" ';
     }
+    if(isset($params["usemap"])) {
+      $value .= ' usemap="'.$params["usemap"].'" ';
+    }
     unset($page);
     break;
   case "embed":
@@ -595,7 +601,10 @@ function twdocs_place_reference($params, &$node) {
     $value .= "/>";
   }
   else {
-    $value .= "alt=\"".$params["alt"]."\"";
+    if( !isset($params["usemap"]) )
+    {
+	$value .= "alt=\"".$params["alt"]."\"";
+    }
     if($params["mode"]=="img")
       $value .= " title=\"".$params["alt"]."\" /></a>";
     else {


### PR DESCRIPTION
Was replacing the uri in the drupal page with the latest revision uri. But we don't need to do that for two reasons
1. We should always be using the "latest" uri in sparql tags
2. For the document tags we only use the name of the file and get the latest version from the latest symbolic link
